### PR TITLE
Bump bcftools version

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -11,7 +11,7 @@ RUN apt update && apt-get install --no-install-recommends -y \
     liblzma-dev \
     zlib1g-dev
 
-ENV BCFTOOLS_VERSION="1.19"
+ENV BCFTOOLS_VERSION="1.20"
 RUN wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
     && tar xjf bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
     && rm bcftools-${BCFTOOLS_VERSION}.tar.bz2 \


### PR DESCRIPTION
Trying to build the docker image results in an error:

```
5.686 --2024-10-15 06:34:31--  https://software.broadinstitute.org/software/score/score_1.19-dev.zip
5.692 Resolving software.broadinstitute.org (software.broadinstitute.org)... 69.173.68.145
5.775 Connecting to software.broadinstitute.org (software.broadinstitute.org)|69.173.68.145|:443... connected.
6.027 HTTP request sent, awaiting response... 404 Not Found
6.273 2024-10-15 06:34:31 ERROR 404: Not Found.
```

Indeed, score 1.19-dev doesn't seem to exist (anymore?). This PR bumps the bcftools version to 1.20, which is the latest one available for score.