### PR TITLE
Apply a few tweaks to improve production deployments

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -47,5 +47,6 @@ RUN python3 -m pip install --upgrade -r /requirements.txt
 COPY server.py /
 
 ENV PORT=8080
+ENV WORKERS=7
 
-CMD exec gunicorn --preload --bind :$PORT --workers 7 --timeout 0 server:app
+CMD exec gunicorn --preload --bind :$PORT --workers $WORKERS --timeout 0 server:app

--- a/service/server.py
+++ b/service/server.py
@@ -15,7 +15,7 @@ app = Flask(__name__)
 
 CORS(app)
 
-DEBUG = True  #if socket.gethostname() == "spliceai-lookup" else True
+DEBUG = os.environ.get('DEBUG', '1').lower() in ['true', '1', 't']
 if not DEBUG:
     Talisman(app)
 
@@ -370,4 +370,6 @@ def run_liftover():
 def catch_all(path):
     return "liftover api"
 
-app.run(debug=DEBUG, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+
+if __name__ == '__main__':
+    app.run(debug=DEBUG, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
We use this service internally, with a few small tweaks to improve deployments. This PR is purely informative, feel free to ignore/close it.

Changes:

- Make DEBUG configurable with an env var, defaulting to 1 to keep backwards compatibility
- Allow the number of workers to be passed via an env var, defaulting to 7 for BC
- Don't call `app.run` if server.py is used as a module (as we do with gunicorn)

Especially the last point is useful, because without it the docker image runs the flask built-in server instead of the gunicorn WSGI.  You can see this if you run the old docker image:

```
$ docker run --rm liftover:pr-old
 * Serving Flask app 'server'
 * Debug mode: on
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:8080
 * Running on http://172.17.0.2:8080
Press CTRL+C to quit
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 216-938-761
```

If you interrupt (`ctrl-c`) this, only then is gunicorn started:

```
[2025-01-28 07:32:24 +0000] [1] [INFO] Starting gunicorn 23.0.0
[2025-01-28 07:32:24 +0000] [1] [ERROR] Connection in use: ('', 8080)
[2025-01-28 07:32:24 +0000] [1] [ERROR] connection to ('', 8080) failed: [Errno 98] Address already in use
[2025-01-28 07:32:24 +0000] [1] [ERROR] Worker (pid:7) was sent SIGKILL! Perhaps out of memory?
[2025-01-28 07:32:25 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080 (1)
[2025-01-28 07:32:25 +0000] [1] [INFO] Using worker: sync
[2025-01-28 07:32:25 +0000] [9] [INFO] Booting worker with pid: 9
[2025-01-28 07:32:25 +0000] [10] [INFO] Booting worker with pid: 10
[2025-01-28 07:32:25 +0000] [11] [INFO] Booting worker with pid: 11
[2025-01-28 07:32:25 +0000] [12] [INFO] Booting worker with pid: 12
[2025-01-28 07:32:25 +0000] [13] [INFO] Booting worker with pid: 13
[2025-01-28 07:32:25 +0000] [14] [INFO] Booting worker with pid: 14
[2025-01-28 07:32:26 +0000] [15] [INFO] Booting worker with pid: 15
```

Compared to the new docker image, which runs gunicorn directly:

```
$ docker run --rm  liftover:pr-new
[2025-01-28 07:35:23 +0000] [1] [INFO] Starting gunicorn 23.0.0
[2025-01-28 07:35:23 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080 (1)
[2025-01-28 07:35:23 +0000] [1] [INFO] Using worker: sync
[2025-01-28 07:35:23 +0000] [7] [INFO] Booting worker with pid: 7
[2025-01-28 07:35:23 +0000] [8] [INFO] Booting worker with pid: 8
[2025-01-28 07:35:23 +0000] [9] [INFO] Booting worker with pid: 9
[2025-01-28 07:35:23 +0000] [10] [INFO] Booting worker with pid: 10
[2025-01-28 07:35:23 +0000] [11] [INFO] Booting worker with pid: 11
[2025-01-28 07:35:24 +0000] [12] [INFO] Booting worker with pid: 12
[2025-01-28 07:35:24 +0000] [13] [INFO] Booting worker with pid: 13
```