### PR TITLE
Update to a newer base image

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.9-slim-bookworm
 
 RUN apt update && apt-get install --no-install-recommends -y \
     ca-certificates \


### PR DESCRIPTION
The USCS liftover tool is installed using this command:

```
wget https://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/liftOver
```

This downloads the most recent version (it doesn't seem to be possible to target a specific version via this site). However, the recent versions of the `liftOver` tool require a libc version higher than is available in the base bullseye image.

This PR updates the base to bookworm, which has a more recent libc version. In my tests so far this works fine.

To compare, output for the old version:

```sh
$ docker build . -qt liftover:test && docker run --rm liftover:test liftOver
sha256:0a86ab0d0175feed27b87b8a13c199e68f3ef6ccc224bee17ca30c88537f2f5c
liftOver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by liftOver)
liftOver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by liftOver)
liftOver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by liftOver)
```

And after this PR:

```sh
$ docker build . -qt liftover:test && docker run --rm liftover:test liftOver
sha256:ab08fa7cc27f4d774821c86d612cc005518d0c70c1f8e8ed662185e6e0495037
liftOver - Move annotations from one assembly to another
usage:
   liftOver oldFile map.chain newFile unMapped
oldFile and newFile are in bed format by default, but can be in GFF and
... and so on
```